### PR TITLE
Move playwright chromium install into build script

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -11,7 +11,7 @@ All commands are run from the root of the project, from a terminal:
 | Command                | Action                                           |
 | :--------------------- | :----------------------------------------------- |
 | `npm install`          | Installs dependencies                            |
-| `npm run dev`          | Starts local dev server at `localhost:3000`      |
+| `npm run dev`          | Starts local dev server at `localhost:4321`      |
 | `npm run build`        | Build your production site to `./dist/`          |
 | `npm run preview`      | Preview your build locally, before deploying     |
 | `npm run astro ...`    | Run CLI commands like `astro add`, `astro check` |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,5 @@ jobs:
       - name: Execute eslint
         run: npm run eslint
 
-      - name: Install playwright
-        run: npx playwright install
-
       - name: Build
         run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+`egashira.dev` は ega4432 個人のブログ／サイトを構築する Astro プロジェクトである。コンテンツ（ブログ記事）は主に Notion 上で執筆され、スケジュール実行される GitHub Action によって Markdown としてこのリポジトリにインポートされるが、`npm run new` によるローカルでの直接執筆も通常の運用手段の一つである。
+
+## コマンド
+
+- `npm run dev` — ローカル開発サーバーを起動する（Astro のデフォルトである `localhost:4321`。）
+- `npm run build` — `astro check && tsc --noEmit && playwright install chromium && astro build` を実行する。これが正しさを担保する一連のチェックであり、変更が完了したとみなす前に必ず実行すること
+- `npm run preview` — 本番ビルドをローカルでプレビューする
+- `npm run eslint` / `npm run eslint:fix` — `./src` を対象に警告ゼロを条件として lint する
+- `npm run prettier` / `npm run prettier:fix` — リポジトリ全体のフォーマットをチェック／修正する
+- `npm run astro -- <cmd>` — 任意の Astro CLI コマンドを実行する（例: `astro check`）
+- `npm run new` — `src/content/blog` 配下に新規ブログ記事の雛形を対話形式で作成する（title/date/tags/draft/summary/slug を入力）
+- `npm run archive-images` — 最近編集された Notion ページ内の画像を取得し Imgur に再ホストする（`NOTION_API_KEY`、`NOTION_DATABASE_ID`、`IMGUR_*` の環境変数が必要）。`import` ワークフロー内でのみ意味を持つ
+
+このリポジトリにはテストランナー／テストスイートは存在しない。正しさは `astro check`、`tsc --noEmit`、`eslint`、`prettier` によって担保されている。`playwright` はビルドステップ（`rehype-mermaid` が Mermaid 図を SVG にレンダリングする際に Chromium を起動するため）のために devDependency として入っているが、現状 Playwright のテストファイルは存在しない。`npm run build` の一部として `playwright install chromium` が実行されるため、通常は別途手動でのブラウザインストールは不要（`postinstall`／`preinstall` フックはサプライチェーン攻撃の踏み台になり得るため意図的に使用していない）。もし Chromium の起動に失敗すると、Astro のコンテンツローダーはそのエラーを警告ログとして記録するだけで処理を続行し、該当記事の本文が空のままビルドが「成功」してしまう点に注意（Mermaid 記法を含む記事の本文が丸ごと出力されない場合はまずこの Chromium 起動失敗を疑うこと）。
+
+pre-commit フック（husky + lint-staged、`.lintstagedrc.js` 参照）はステージされたファイルに対して prettier、eslint、`astro check` を実行する。CI でも同様のチェックがゲートになると想定してよい。
+
+## アーキテクチャ
+
+### コンテンツパイプライン（Notion → Markdown → Astro）
+
+1. `.github/workflows/import.yaml` はスケジュール実行（3時間ごと）および手動実行に対応している。`npm run archive-images`（`scripts/archive-images.mjs` により Notion の画像を Imgur に再ホスト）を呼んだ後、外部アクション `ega4432/notion-to-markdown-action` を使って Notion のページを `src/content/blog/*.md` にエクスポートし、フロントマターの `slug:` キーを削除し、`draft: true` のファイルを削除した上で、結果を自動コミット・プッシュする。
+2. Astro のコンテンツコレクションは `src/content.config.ts` で定義されており、`src/content/blog` と `src/content/page` に対して `glob()` ローダーを使用し、`src/content/schemes.ts` の Zod スキーマ（`blogScheme`、`pageScheme`）でバリデーションされる。
+3. `src/lib/blog.ts` は `blog` コレクションに対する読み取り用 API である。`getBlogs()`（下書きを除外し日付降順でソート）、`getTags()`（タグの出現数を集計。大文字小文字を無視して重複除去しつつ最初に出現した表記を保持）、`getRelatedBlogs()`（共通タグ数でスコアリングして関連記事を返す）。
+4. ローカルで手動執筆する場合は `npm run new`（`scripts/new-post.ts`）を使う。これは `blogScheme` に合致するフロントマターのみのひな形を書き出す。
+
+記事は通常機械的にインポートされるため、フロントマターの形（`title`、`date`、`tags`、`draft`、`summary`、任意の `createdAt`／`updatedAt`）は契約として扱うこと。`blogScheme` を変更する際は、インポートアクションが出力する内容との互換性を保つ必要がある。
+
+### Markdown レンダリングパイプライン
+
+`astro.config.mjs` 内でカスタムの `unified()` プロセッサとして設定されている（Astro のデフォルトの remark/rehype スタックではない）。
+
+- remark: `remark-emoji`、`remark-math`、および独自プラグイン `src/lib/utils/remark-plugins/remark-link-card.ts`（単独行に置かれた裸の URL をリッチなリンクカードに変換する）
+- rehype: `rehype-slug` → `rehype-autolink-headings`（`src/lib/utils/rehype-plugins/rehype-auto-link-headings.ts` の独自アンカーアイコンを使用）→ `rehype-katex` → `rehype-mermaid`（SVG 画像としてレンダリング、ダークテーマ用の設定を別途持つ）→ `rehype-pretty-code`（Shiki、`github-dark-default` テーマ、diff 記法の transformer 付き）
+
+リンクカードはビルド時に Open Graph データを取得し、`src/lib/ogCache.ts`（`getOgData`/`setOgData`）を介して `public/og-cache.json` に結果をキャッシュする。これにより、変更のない URL をビルドのたびに再スクレイピングすることを避けている。
+
+### OG 画像生成
+
+`src/integrations/generateOgImages.ts` は `astro:build:done` フックを使う独自の Astro インテグレーションである。ビルドされた `blog/*` ページごとに、元の Markdown フロントマターから記事タイトルを（`gray-matter` 経由で）読み取り、`satori` で 1200×630 の画像をレンダリングし（`src/integrations/assets/background.png` と `NotoSansJP-Bold.otf` を使用）、`sharp` で PNG にラスタライズして `dist/images/<page>/og.png` に書き出す。
+
+### サイトメタ情報
+
+サイト全体で使う定数（著者名、URL、説明文、フッターリンク、SNS アカウント、ページサイズなど）はすべて `src/constants.ts`（`siteMeta`、`footerLinks`、`DEFAULT_PAGE_SIZE`）に集約されている。サイトメタ情報を他の場所にハードコードするより、このファイルを編集することを優先すること。`SEO.astro` や `BlogHead.astro` などのコンポーネントはこの形に依存している。
+
+### パスエイリアス
+
+TypeScript のパスエイリアス（`tsconfig.json` 参照）。相対パスの `../../` の代わりにこちらを使うこと。
+
+`@components/*`、`@layouts/*`、`@pages/*`、`@lib/*`、`@content/*`、`@styles/*`、`@integrations/*`、`@constants`（`/*` なしで `src/constants.ts` 自体を指す）、`@scripts/*`
+
+### デプロイ
+
+サイトは Cloudflare Pages 上にデプロイされている。`astro.config.mjs` は `CF_PAGES_BRANCH`／`CF_PAGES_URL` の環境変数に応じて `site` の URL を切り替える（`main` ブランチでは本番 URL、それ以外ではプレビュー URL、どちらもない場合は localhost）。
+
+### その他の生成／特殊ルート
+
+- `src/pages/feed.xml.js` — RSS フィード
+- `src/pages/llms.txt.ts` — サイト全体と公開済み全記事の概要をプレーンテキストで出力する（LLM 向け）
+- `src/pages/tags/` — `getTags()` を利用したタグ一覧・タグ別記事一覧ページ

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "egashira.dev",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@astrojs/check": "^0.9.6",
         "@astrojs/rss": "^4.0.14",
@@ -474,6 +475,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
       "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1208,6 +1210,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1230,6 +1233,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1252,6 +1256,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1268,6 +1273,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1284,6 +1290,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1300,6 +1307,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1316,6 +1324,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1332,6 +1341,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1348,6 +1358,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1364,6 +1375,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1380,6 +1392,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1396,6 +1409,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1412,6 +1426,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1434,6 +1449,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1456,6 +1472,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1478,6 +1495,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1500,6 +1518,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1522,6 +1541,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1544,6 +1564,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1566,6 +1587,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1588,6 +1610,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1607,6 +1630,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1626,6 +1650,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1645,6 +1670,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2383,9 +2409,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2398,9 +2421,6 @@
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2415,9 +2435,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2430,9 +2447,6 @@
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2447,9 +2461,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2462,9 +2473,6 @@
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2479,9 +2487,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2494,9 +2499,6 @@
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2511,9 +2513,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2526,9 +2525,6 @@
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2543,9 +2539,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2559,9 +2552,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2574,9 +2564,6 @@
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9484,6 +9471,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11375,7 +11363,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && tsc --noEmit && astro build",
+    "build": "astro check && tsc --noEmit && playwright install chromium && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "prepare": "husky",


### PR DESCRIPTION
## Summary
- Move `playwright install chromium` into `npm run build` itself so it always runs before `astro build`, instead of as a separate CI-only step (avoids silently empty Mermaid diagrams when chromium isn't installed)
- Remove the now-redundant standalone playwright install step from CI
- Fix `.github/README.md` dev server port docs (3000 → 4321)
- Add `CLAUDE.md` with project guidance for Claude Code

## Test plan
- [x] `npm run prettier:fix` / `npm run eslint:fix` clean
- [x] `npm run astro -- check` / `tsc --noEmit` clean
- [ ] Confirm CI build passes with the updated workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)